### PR TITLE
Fix for first rows being skipped for projections

### DIFF
--- a/src/EventSourcingOnAzureFunctions.Common/EventSourcing/Implementation/AzureStorage/Table/TableEventStreamReader.cs
+++ b/src/EventSourcingOnAzureFunctions.Common/EventSourcing/Implementation/AzureStorage/Table/TableEventStreamReader.cs
@@ -236,7 +236,7 @@ namespace EventSourcingOnAzureFunctions.Common.EventSourcing.Implementation.Azur
         /// </param>
         private string CreateQuery(int StartingSequenceNumber)
         {
-            return TableClient.CreateQueryFilter($"PartitionKey eq {InstanceKey} and RowKey gt {SequenceNumberAsString(StartingSequenceNumber)} ");
+            return TableClient.CreateQueryFilter($"PartitionKey eq {InstanceKey} and RowKey ge {SequenceNumberAsString(StartingSequenceNumber)} ");
         }
 
         /// <summary>

--- a/src/EventSourcingOnAzureFunctions.Common/EventSourcing/Implementation/ClassificationProcessor.cs
+++ b/src/EventSourcingOnAzureFunctions.Common/EventSourcing/Implementation/ClassificationProcessor.cs
@@ -43,7 +43,7 @@ namespace EventSourcingOnAzureFunctions.Common.EventSourcing.Implementation
                             }
                             if (ret == ClassificationResponse.ClassificationResults.Exclude)
                             {
-                                wasEverIncluded = true;
+                                wasEverExcluded = true;
                             }
                         }
                     }


### PR DESCRIPTION
Duncan hey,
commit 9e0776dff3f5058984caed1cb3f4e834efe05705, in TableEventStreamReader reads:

```c#
TableQuery.GenerateFilterCondition("RowKey",
                         QueryComparisons.GreaterThanOrEqual,
                         SequenceNumberAsString(StartingSequenceNumber)
````
is changed to

```c#
RowKey gt {SequenceNumberAsString(StartingSequenceNumber)}
```

`gt` should be `ge` instead to keep the same comparison. At the moment while projecting, first rows are skipped.

And eh, <3 your work, thanks for this awesome library :)